### PR TITLE
Disable cache on non-v8 versions of Node

### DIFF
--- a/v8-compile-cache.js
+++ b/v8-compile-cache.js
@@ -290,7 +290,7 @@ function slashEscape(str) {
 
 function supportsCachedData() {
   var script = new vm.Script('""', {produceCachedData: true});
-  return script.cachedDataProduced != null;
+    return process.versions.v8 && script.cachedDataProduced != null;
 }
 
 function getCacheDir() {

--- a/v8-compile-cache.js
+++ b/v8-compile-cache.js
@@ -290,7 +290,7 @@ function slashEscape(str) {
 
 function supportsCachedData() {
   var script = new vm.Script('""', {produceCachedData: true});
-    return process.versions.v8 && script.cachedDataProduced != null;
+  return process.versions.v8 && script.cachedDataProduced != null;
 }
 
 function getCacheDir() {


### PR DESCRIPTION
Recently I was playing around with ChakraCore's implementation of Node (https://github.com/nodejs/node-chakracore) and noticed that v8-compile-cache fails since `process.version.v8` is not set.  I did some experimentation and it seems that running the cache in Chakra causes segmentation faults on version 8.3 and nightlies, so I just made sure that the cache only initializes for v8.  I'm not even sure if, philosophically, a package called `v8-compiler-cache` *should* enable a cache for other implementations of Node, but I will do my best to watch Chakra's development and get another PR to enable the cache if support comes.