### PR TITLE
Parameterize cache creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,25 @@ The ability to tap into V8 to produce/consume this cache was introduced in [Node
 
 ## Options
 
+### DISABLE_V8_COMPILE_CACHE
+
 Set the environment variable `DISABLE_V8_COMPILE_CACHE=1` to disable the cache.
+
+### V8_COMPILE_CACHE_DIR
+
+Set the environment variable `V8_COMPILE_CACHE_DIR=<dir>` to save caches to specific directory. Valid are these:
+* `/var/tmp/somedir`
+* `cwddir`
+* `~/homedir`
+
+### V8_COMPILE_CACHE_PREFIX_ROOT
+
+Set the environment variable `V8_COMPILE_CACHE_PREFIX_ROOT=<dir>` to change cache prefix from absolute path to relative to some directory.
+
+It means that cache is saved in file named using relative to this directory path instead of absolute path, for example:
+* require is placed in file `/home/rick/projects/prj1/lib/index.js`
+* default cache name is produced from `/home/rick/projects/prj1/lib/index.js`
+* with this variable set to `/home/rick/projects/prj1` cache name is produced from `lib/index.js`.
 
 ## Internals
 

--- a/test/getParentName-test.js
+++ b/test/getParentName-test.js
@@ -2,6 +2,7 @@
 
 const tap = require('tap');
 const child_process = require('child_process');
+const path = require('path');
 
 tap.beforeEach(cb => {
   delete process.env.DISABLE_V8_COMPILE_CACHE;
@@ -64,6 +65,23 @@ tap.test('module.parent.filename works with as arg script', t => {
     {cwd: __dirname}
   );
   t.equal(ps.status, 0);
+
+  t.end();
+});
+
+tap.test('with V8_COMPILE_CACHE_PREFIX_ROOT', t => {
+  const ps = child_process.spawnSync(
+    process.execPath,
+    ['--eval', `
+      console.log(require('..').__TEST__.getParentName());
+    `],
+    {cwd: __dirname, env: {V8_COMPILE_CACHE_PREFIX_ROOT: path.join(__dirname, '..', '..')}}
+  );
+  t.equal(ps.status, 0);
+
+  const nameParts = String(ps.stdout).trim().split(path.sep);
+  t.equal(nameParts[0], path.basename(path.join(__dirname, '..')));
+  t.equal(nameParts[1], 'test');
 
   t.end();
 });

--- a/v8-compile-cache.js
+++ b/v8-compile-cache.js
@@ -294,7 +294,19 @@ function supportsCachedData() {
   return script.cachedDataProduced === true;
 }
 
+function getAbsolutePath(p) {
+  const parts = p.split(path.sep);
+  const cacheDir = parts[0] === '~'
+      ? path.resolve(path.join.apply(null, [].concat(process.env.HOME, parts.slice(1))))
+      : path.resolve(p);
+  return cacheDir;
+}
+
 function getCacheDir() {
+  if (process.env.V8_COMPILE_CACHE_DIR) {
+    return getAbsolutePath(process.env.V8_COMPILE_CACHE_DIR);
+  }
+
   // Avoid cache ownership issues on POSIX systems.
   const dirname = typeof process.getuid === 'function'
     ? 'v8-compile-cache-' + process.getuid()
@@ -316,6 +328,10 @@ function getParentName() {
   const parentName = module.parent && typeof module.parent.filename === 'string'
     ? module.parent.filename
     : process.cwd();
+  if (process.env.V8_COMPILE_CACHE_PREFIX_ROOT) {
+    const root = getAbsolutePath(process.env.V8_COMPILE_CACHE_PREFIX_ROOT);
+    return path.relative(root, parentName);
+  }
   return parentName;
 }
 
@@ -348,4 +364,5 @@ module.exports.__TEST__ = {
   supportsCachedData,
   getCacheDir,
   getParentName,
+  getAbsolutePath,
 };


### PR DESCRIPTION
We want to save compile cache and then use it on other machines. 
So we need to specify cache dir and root directory from which we calculate prefix because absolute paths might be different on different machines