### PR TITLE
Add Buffer to args array for Electron require

### DIFF
--- a/v8-compile-cache.js
+++ b/v8-compile-cache.js
@@ -174,7 +174,7 @@ class NativeCompileCache {
       // We skip the debugger setup because by the time we run, node has already
       // done that itself.
 
-      const args = [mod.exports, require, mod, filename, dirname, process, global];
+      const args = [mod.exports, require, mod, filename, dirname, process, global, Buffer];
       return compiledWrapper.apply(mod.exports, args);
     };
   }


### PR DESCRIPTION
Electron's module wrapper require an addtional global Buffer. 

This was the PR where Electron added the additonal Buffer to the node module loader 
[https://github.com/electron/electron/pull/8605](https://github.com/electron/electron/pull/8605)

[https://github.com/electron/node/blob/18aeda2077e7fe1ef9d7557692dda2e4d6a61860/lib/internal/modules/cjs/loader.js#L136](https://github.com/electron/node/blob/18aeda2077e7fe1ef9d7557692dda2e4d6a61860/lib/internal/modules/cjs/loader.js#L136)