### PR TITLE
Expose `require.resolve.paths()`

### DIFF
--- a/test/fixtures/resolve-paths.js
+++ b/test/fixtures/resolve-paths.js
@@ -1,0 +1,1 @@
+console.log(JSON.stringify(require.resolve.paths('tap')));

--- a/test/resolvePaths-test.js
+++ b/test/resolvePaths-test.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const tap = require('tap');
+const child_process = require('child_process');
+const semver = require('semver');
+
+tap.beforeEach(cb => {
+  delete process.env.DISABLE_V8_COMPILE_CACHE;
+  cb();
+});
+
+const hasRequireResolvePaths = semver.satisfies(process.versions.node, '>=8.9.0');
+if (hasRequireResolvePaths) {
+  tap.test('does not override require.resolve.paths()', t => {
+    const ps = child_process.spawnSync(
+      process.execPath,
+      ['--require', '..', require.resolve('./fixtures/resolve-paths')],
+      {cwd: __dirname}
+    );
+    t.equal(ps.status, 0);
+    t.equal(Array.isArray(JSON.parse(String(ps.stdout).trim())), true);
+
+    t.end();
+  });
+}

--- a/v8-compile-cache.js
+++ b/v8-compile-cache.js
@@ -8,6 +8,7 @@ const vm = require('vm');
 const os = require('os');
 
 const hasOwnProperty = Object.prototype.hasOwnProperty;
+const resolvePaths = require.resolve.paths;
 
 //------------------------------------------------------------------------------
 // FileSystemBlobStore
@@ -161,6 +162,7 @@ class NativeCompileCache {
       require.resolve = function(request, options) {
         return Module._resolveFilename(request, mod, false, options);
       };
+      require.resolve.paths = resolvePaths;
       require.main = process.mainModule;
 
       // Enable support to add extra extension types


### PR DESCRIPTION
As outlined in #17 - overriding `require.resolve` removes `require.resolve.paths` from existence. This PR ensures it is proxies as-is.

Closes #17 