### PR TITLE
Run linter as post-test task

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "bench": "bench/run.sh",
     "lint": "eslint --max-warnings=0 .",
-    "test": "tap test/*-test.js"
+    "test": "tap test/*-test.js",
+    "posttest": "npm run lint"
   },
   "author": "Andres Suarez <zertosh@gmail.com>",
   "files": [


### PR DESCRIPTION
I submitted a PR which `npm test` reported as fine in development locally, but failed on travis. This was due to the lint task only being run on the CI.

This PR adds the lint task as a post-test task (it'll only run if the other tests pass, so generally shouldn't interfere with any workflow)