### PR TITLE
Expose `require.resolve.paths()`

### DIFF
--- a/test/fixtures/require-resolve-paths.js
+++ b/test/fixtures/require-resolve-paths.js
@@ -1,0 +1,9 @@
+console.log(
+  '%j',
+  {
+    hasRequireResolve: typeof require.resolve.paths === 'function',
+    value: typeof require.resolve.paths === 'function'
+      ? require.resolve.paths(process.argv[2])
+      : undefined
+  }
+);

--- a/test/module-test.js
+++ b/test/module-test.js
@@ -1,0 +1,68 @@
+'use strict';
+
+const child_process = require('child_process');
+const tap = require('tap');
+const semver = require('semver');
+
+tap.beforeEach(cb => {
+  delete process.env.DISABLE_V8_COMPILE_CACHE;
+  cb();
+});
+
+tap.test('require.resolve.paths module', t => {
+  const psWithoutCache = child_process.spawnSync(
+    process.execPath,
+    [require.resolve('./fixtures/require-resolve-paths'), 'tap'],
+    {cwd: __dirname}
+  );
+
+  const psWithCache = child_process.spawnSync(
+    process.execPath,
+    [
+      '--require',
+      '..',
+      require.resolve('./fixtures/require-resolve-paths'),
+      'tap',
+    ],
+    {cwd: __dirname}
+  );
+
+  const actual = JSON.parse(psWithCache.stdout);
+  const expected = JSON.parse(psWithoutCache.stdout);
+
+  t.same(actual, expected);
+  t.equal(psWithCache.stderr.toString(), '');
+  t.equal(psWithCache.status, 0);
+
+  t.equal(
+    actual.hasRequireResolve,
+    semver.satisfies(process.versions.node, '>=8.9.0')
+  );
+
+  t.end();
+});
+
+tap.test('require.resolve.paths relative', t => {
+  const psWithoutCache = child_process.spawnSync(
+    process.execPath,
+    [require.resolve('./fixtures/require-resolve-paths'), './foo'],
+    {cwd: __dirname}
+  );
+
+  const psWithCache = child_process.spawnSync(
+    process.execPath,
+    [
+      '--require',
+      '..',
+      require.resolve('./fixtures/require-resolve-paths'),
+      './foo',
+    ],
+    {cwd: __dirname}
+  );
+
+  t.same(JSON.parse(psWithCache.stdout), JSON.parse(psWithoutCache.stdout));
+  t.equal(psWithCache.stderr.toString(), '');
+  t.equal(psWithCache.status, 0);
+
+  t.end();
+});

--- a/v8-compile-cache.js
+++ b/v8-compile-cache.js
@@ -152,15 +152,29 @@ class NativeCompileCache {
 
   install() {
     const self = this;
+    const hasRequireResolvePaths = typeof require.resolve.paths === 'function';
     this._previousModuleCompile = Module.prototype._compile;
     Module.prototype._compile = function(content, filename) {
       const mod = this;
+
       function require(id) {
         return mod.require(id);
       }
-      require.resolve = function(request, options) {
+
+      // https://github.com/nodejs/node/blob/v10.15.3/lib/internal/modules/cjs/helpers.js#L28
+      function resolve(request, options) {
         return Module._resolveFilename(request, mod, false, options);
-      };
+      }
+      require.resolve = resolve;
+
+      // https://github.com/nodejs/node/blob/v10.15.3/lib/internal/modules/cjs/helpers.js#L37
+      // resolve.resolve.paths was added in v8.9.0
+      if (hasRequireResolvePaths) {
+        resolve.paths = function paths(request) {
+          return Module._resolveLookupPaths(request, mod, true);
+        };
+      }
+
       require.main = process.mainModule;
 
       // Enable support to add extra extension types


### PR DESCRIPTION
This was added in v8.9.0:
https://nodejs.org/api/modules.html#modules_require_resolve_paths_request

Closes #20 
Fixes #17 