### PR TITLE
Stop using process.umask()

### DIFF
--- a/v8-compile-cache.js
+++ b/v8-compile-cache.js
@@ -272,7 +272,7 @@ class NativeCompileCache {
 //------------------------------------------------------------------------------
 
 function mkdirpSync(p_) {
-  _mkdirpSync(path.resolve(p_), parseInt('0777', 8) & ~process.umask());
+  _mkdirpSync(path.resolve(p_), 0o777);
 }
 
 function _mkdirpSync(p, mode) {


### PR DESCRIPTION
It's deprecated in the latest Node.js due to being insecure and
it's not necessary to use it in the first place because the umask
is automatically applied when creating the directory.

Refs: https://github.com/nodejs/node/issues/32321
Refs: https://github.com/isaacs/node-mkdirp/issues/22

Can you publish a new version after merging this? Thanks.