### PR TITLE
fix: use require.main instead of module.parent

### DIFF
--- a/bench/_measure.js
+++ b/bench/_measure.js
@@ -7,7 +7,7 @@ module.exports = (name, withCache, callback) => {
   logs.push(`node: ${parseInt(process.uptime() * 1000, 10)}ms`);
 
   // So each test gets its own cache
-  module.filename = module.parent.filename;
+  module.filename = require.main.filename;
   s = Date.now();
   if (withCache) require('../v8-compile-cache');
   logs.push(`require-cache: ${Date.now() - s}ms`);

--- a/test/fixtures/print-main-name.js
+++ b/test/fixtures/print-main-name.js
@@ -1,0 +1,1 @@
+console.log(require('../..').__TEST__.getMainName());

--- a/test/fixtures/print-parent-name.js
+++ b/test/fixtures/print-parent-name.js
@@ -1,1 +1,0 @@
-console.log(require('../..').__TEST__.getParentName());

--- a/test/getMainName-test.js
+++ b/test/getMainName-test.js
@@ -11,7 +11,7 @@ tap.beforeEach(cb => {
 tap.test('handles --require', t => {
   const ps = child_process.spawnSync(
     process.execPath,
-    ['--require', '..', require.resolve('./fixtures/print-parent-name')],
+    ['--require', '..', require.resolve('./fixtures/print-main-name')],
     {cwd: __dirname}
   );
   t.equal(ps.status, 0);
@@ -20,12 +20,12 @@ tap.test('handles --require', t => {
   t.end();
 });
 
-tap.test('bad module.parent.filename', t => {
+tap.test('bad require.main.filename', t => {
   const ps = child_process.spawnSync(
     process.execPath,
     ['--eval', `
       module.filename = null;
-      console.log(require('..').__TEST__.getParentName());
+      console.log(require('..').__TEST__.getMainName());
     `],
     {cwd: __dirname}
   );
@@ -35,7 +35,7 @@ tap.test('bad module.parent.filename', t => {
   t.end();
 });
 
-tap.test('module.parent.filename works with --eval', t => {
+tap.test('require.main.filename works with --eval', t => {
   const ps = child_process.spawnSync(
     process.execPath,
     ['--eval', 'require("..")'],
@@ -46,7 +46,7 @@ tap.test('module.parent.filename works with --eval', t => {
   t.end();
 });
 
-tap.test('module.parent.filename works with --require', t => {
+tap.test('require.main.filename works with --require', t => {
   const ps = child_process.spawnSync(
     process.execPath,
     ['--require', '..'],
@@ -57,7 +57,7 @@ tap.test('module.parent.filename works with --require', t => {
   t.end();
 });
 
-tap.test('module.parent.filename works with as arg script', t => {
+tap.test('require.main.filename works with as arg script', t => {
   const ps = child_process.spawnSync(
     process.execPath,
     [require.resolve('..')],

--- a/v8-compile-cache.js
+++ b/v8-compile-cache.js
@@ -328,15 +328,15 @@ function getCacheDir() {
   return cacheDir;
 }
 
-function getParentName() {
-  // `module.parent.filename` is undefined or null when:
+function getMainName() {
+  // `require.main.filename` is undefined or null when:
   //    * node -e 'require("v8-compile-cache")'
   //    * node -r 'v8-compile-cache'
   //    * Or, requiring from the REPL.
-  const parentName = module.parent && typeof module.parent.filename === 'string'
-    ? module.parent.filename
+  const mainName = require.main && typeof require.main.filename === 'string'
+    ? require.main.filename
     : process.cwd();
-  return parentName;
+  return mainName;
 }
 
 //------------------------------------------------------------------------------
@@ -345,7 +345,7 @@ function getParentName() {
 
 if (!process.env.DISABLE_V8_COMPILE_CACHE && supportsCachedData()) {
   const cacheDir = getCacheDir();
-  const prefix = getParentName();
+  const prefix = getMainName();
   const blobStore = new FileSystemBlobStore(cacheDir, prefix);
 
   const nativeCompileCache = new NativeCompileCache();
@@ -367,5 +367,5 @@ module.exports.__TEST__ = {
   slashEscape,
   supportsCachedData,
   getCacheDir,
-  getParentName,
+  getMainName,
 };


### PR DESCRIPTION
The latter is a deprecated API.

Refs: https://nodejs.org/dist/latest-v15.x/docs/api/deprecations.html#DEP0144
