### PR TITLE
fix: add tests and better error for dynamic imports

### DIFF
--- a/test/esm-test.js
+++ b/test/esm-test.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const child_process = require('child_process');
+const tap = require('tap');
+
+tap.test('support dynamic imports', t => {
+  const psWithCache = child_process.spawnSync(
+    process.execPath,
+    [
+      '--require',
+      '..',
+      require.resolve('./fixtures/dynamic-import.js')
+    ],
+    {cwd: __dirname}
+  );
+
+  t.equal(psWithCache.stdout.toString('utf8').trim(), 'file-4');
+  t.equal(psWithCache.status, 0);
+
+  t.end();
+});
+

--- a/test/fixtures/dynamic-import.js
+++ b/test/fixtures/dynamic-import.js
@@ -1,0 +1,1 @@
+import('./file-4.js').then(r => console.log(r.default()))

--- a/v8-compile-cache.js
+++ b/v8-compile-cache.js
@@ -243,6 +243,10 @@ class NativeCompileCache {
       displayErrors: true,
       cachedData: buffer,
       produceCachedData: true,
+      // https://nodejs.org/api/vm.html#vm_new_vm_script_code_options
+      importModuleDynamically() {
+        throw new Error('[v8-compile-cache] Dynamic imports are currently not supported. See https://git.io/Jge6z for more information.')
+      }
     });
 
     if (script.cachedDataProduced) {


### PR DESCRIPTION
Reference: #30

- Add failing test for dynamic imports
- Add a more relevant error for dynamic imports

In order to support dynamic imports and implement `importModuleDynamically`, we have to use [vm.SourceModuleText](https://nodejs.org/api/vm.html#vm.SourceTextModule) which is still experimental and only available behind `--experimental-vm-modules` flag. Yet current situation might be super confusing especially when users are not directly using `v8-compile-cache` and see a clueless error like this:

```
(node:8373) UnhandledPromiseRejectionWarning: TypeError [ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING]: A dynamic import callback was not specified.
    at exports.importModuleDynamicallyCallback (internal/process/esm_loader.js:34:9)
    at Object.<anonymous> (/home/pooya/Code/v8-compile-cache/test/fixtures/dynamic-import.js:1:63)
    at Module._compile (/home/pooya/Code/v8-compile-cache/v8-compile-cache.js:192:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1101:10)
    at Module.load (internal/modules/cjs/loader.js:937:32)
    at Function.Module._load (internal/modules/cjs/loader.js:778:12)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:76:12)
    at internal/main/run_main_module.js:17:47
(Use `node --trace-warnings ...` to show where the warning was created)
```

After this PR: ([git.io link](https://git.io/Jge6z) redirects to #300)

```
(node:8503) UnhandledPromiseRejectionWarning: Error: [v8-compile-cache] Dynamic imports are currently not supported. See https://git.io/Jge6z for more information.
    at importModuleDynamically (./home/pooya/Code/v8-compile-cache/v8-compile-cache.js:248:15)
```

----

I would be happy to also help in the future with the actual implementation of the VM cache 😊
