### PR TITLE
tap: protect getCacheDir test with --no-cov

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "bench": "bench/run.sh",
     "eslint": "eslint --max-warnings=0 .",
-    "tap": "tap test/*-test.js",
+    "tap": "tap --no-cov test/*-test.js",
     "test": "npm run tap",
     "posttest": "npm run eslint"
   },


### PR DESCRIPTION
Tap might have coverage on by default, which nukes that test.