### PR TITLE
Add arch to cache directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # `v8-module-cache` Changelog
 
+## Next
+
+* Fix segmentation fault with Rosetta on Apple Silicon [#45](https://github.com/zertosh/v8-compile-cache/pull/45).
+
 ## 2021-03-05, Version 2.3.0
 
 * Fix use require.main instead of module.parent [#34](https://github.com/zertosh/v8-compile-cache/pull/34).

--- a/test/arch/run.sh
+++ b/test/arch/run.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -eo pipefail
+
+THIS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+: "${NODE_BIN:=node}"
+
+if [ "$(/usr/bin/arch)" != "arm64" ]; then
+  echo "arch/run.sh: This must be run on Apple Silicon." >&2
+  exit
+fi
+
+# shellcheck disable=SC2016
+"$NODE_BIN" "$THIS_DIR/yarn.js" config get init.author.name >/dev/null
+/usr/bin/arch -x86_64 "$NODE_BIN" "$THIS_DIR/yarn.js" config get init.author.name >/dev/null
+
+echo "Success!"

--- a/test/arch/yarn.js
+++ b/test/arch/yarn.js
@@ -1,0 +1,4 @@
+'use strict';
+
+require ('../../v8-compile-cache.js');
+require('yarn/lib/cli.js');

--- a/test/getCacheDir-test.js
+++ b/test/getCacheDir-test.js
@@ -14,7 +14,8 @@ tap.test('getCacheDir (v8)', t => {
   const nameParts = parts[1].split(path.sep);
 
   t.match(nameParts[1], /^v8-compile-cache(-\d+)?$/);
-  t.equal(nameParts[2], process.versions.v8);
+  t.equal(nameParts[2], process.arch);
+  t.equal(nameParts[3], process.versions.v8);
 
   t.done();
 });
@@ -24,6 +25,7 @@ tap.test('getCacheDir (chakracore)', t => {
     '(' + getCacheDir.toString() + ')();',
     {
       process: {
+        arch: process.arch,
         getuid: process.getuid,
         versions: {chakracore: '1.2.3'},
         env: {},
@@ -37,7 +39,7 @@ tap.test('getCacheDir (chakracore)', t => {
   const nameParts = parts[1].split(path.sep);
 
   t.match(nameParts[1], /^v8-compile-cache(-\d+)?$/);
-  t.equal(nameParts[2], 'chakracore-1.2.3');
+  t.equal(nameParts[3], 'chakracore-1.2.3');
 
   t.done();
 });
@@ -47,6 +49,7 @@ tap.test('getCacheDir (unknown)', t => {
     '(' + getCacheDir.toString() + ')();',
     {
       process: {
+        arch: process.arch,
         getuid: process.getuid,
         version: '1.2.3',
         versions: {},
@@ -60,7 +63,7 @@ tap.test('getCacheDir (unknown)', t => {
   const parts = cacheDir.split(os.tmpdir());
   const nameParts = parts[1].split(path.sep);
   t.match(nameParts[1], /^v8-compile-cache(-\d+)?$/);
-  t.equal(nameParts[2], 'node-1.2.3');
+  t.equal(nameParts[3], 'node-1.2.3');
 
   t.done();
 });
@@ -70,6 +73,7 @@ tap.test('getCacheDir (env)', t => {
     '(' + getCacheDir.toString() + ')();',
     {
       process: {
+        arch: process.arch,
         getuid: process.getuid,
         versions: {},
         env: {

--- a/v8-compile-cache.js
+++ b/v8-compile-cache.js
@@ -319,12 +319,14 @@ function getCacheDir() {
   const dirname = typeof process.getuid === 'function'
     ? 'v8-compile-cache-' + process.getuid()
     : 'v8-compile-cache';
+  // Avoid cache incompatibility issues with Rosetta on Apple Silicon.
+  const arch = process.arch;
   const version = typeof process.versions.v8 === 'string'
     ? process.versions.v8
     : typeof process.versions.chakracore === 'string'
       ? 'chakracore-' + process.versions.chakracore
       : 'node-' + process.version;
-  const cacheDir = path.join(os.tmpdir(), dirname, version);
+  const cacheDir = path.join(os.tmpdir(), dirname, arch, version);
   return cacheDir;
 }
 


### PR DESCRIPTION
We're seeing issues on Apple Silicon device where the following would segmentation fault:

```
$ node script-using-v8-compile-cache.js
$ arch -x86_64 node script-using-v8-compile-cache.js
```

This change fixes the problem.

**Test Plan:**

Verify tests pass.

```
$ yarn test
```

Verify the architecture test fails on Apple Silicon without the `arch` fix:

```
$ ./test/arch/run.sh 
./test/arch/run.sh: line 15: 85082 Segmentation fault: 11  /usr/bin/arch -x86_64 "$NODE_BIN" "$THIS_DIR/yarn.js" config get init.author.name > /dev/null
```

Verify the architecture test succeeds with the `arch` fix:

```
$ ./test/arch/run.sh 
Success!
```