### PR TITLE
Workaround for loading ESM

### DIFF
--- a/bench/esm/import-chalk.js
+++ b/bench/esm/import-chalk.js
@@ -1,0 +1,5 @@
+(async () => {
+  // Evaluating the dynamic import is a workaround for loading ESM in CJS files
+  const { default: chalk } = await (Function(`return import("chalk")`)());
+  console.log(chalk.blue("Hello World"));
+})();

--- a/bench/esm/import-local-file.js
+++ b/bench/esm/import-local-file.js
@@ -1,0 +1,5 @@
+(async () => {
+  // Evaluating the dynamic import is a workaround for loading ESM in CJS files
+  const {default: log} = await (Function(`return import("./local-file.mjs")`)());
+  log();
+})();

--- a/bench/esm/local-file.mjs
+++ b/bench/esm/local-file.mjs
@@ -1,0 +1,3 @@
+export default function () {
+  console.log('Hello World')
+}

--- a/bench/require-import-chalk.js
+++ b/bench/require-import-chalk.js
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+'use strict';
+
+const WITH_CACHE = true;
+
+require('./_measure.js')('require-chalk', WITH_CACHE, () => {
+  // Node introduced support for dynamics import in v12
+  const NODE_MAJOR_VERSION = process.versions.node.split('.')[0];
+  if (NODE_MAJOR_VERSION < 12) {
+    return;
+  }
+
+  process.argv.push('config', 'get', 'init.author.name');
+  require('./esm/import-chalk.js');
+});

--- a/bench/require-import-local-file.js
+++ b/bench/require-import-local-file.js
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+'use strict';
+
+const WITH_CACHE = true;
+
+require('./_measure.js')('require-local-file', WITH_CACHE, () => {
+  // Node introduced support for dynamics import in v12
+  const NODE_MAJOR_VERSION = process.versions.node.split('.')[0];
+  if (NODE_MAJOR_VERSION < 12) {
+    return;
+  }
+  
+  process.argv.push('config', 'get', 'init.author.name');
+  require('./esm/import-local-file.js');
+});

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {},
   "devDependencies": {
     "babel-core": "6.26.3",
+    "chalk": "^5.3.0",
     "eslint": "^7.12.1",
     "flow-parser": "0.136.0",
     "rimraf": "^2.5.4",

--- a/sandbox-esm/index.js
+++ b/sandbox-esm/index.js
@@ -1,0 +1,5 @@
+(async () => {
+  require("../v8-compile-cache.js");
+  require('../bench/esm/import-chalk.js');
+  require('./requires-local-file/requires-local-file.js');
+})();


### PR DESCRIPTION
This is an initial workaround for loading files with ESM imports.

This works by adding the `importModuleDynamically` option in `vm.Script` constructor, which is required when the script has dynamics `imports()`. In this case, the cache is also disabled because otherwise it would throw "Invalid host defined options" (I wasn't able to find out why).

I've added a couple benchmark cases, all of them are working with Node 10 and 18.

I'm not familiar with Node `vm` logic. This said, I believe this change only affects required files with ESM imports, which are not working at all now, so it shouldn't have side effects for other cases.

Edit: fixes https://github.com/zertosh/v8-compile-cache/issues/41